### PR TITLE
update babyjub auth signature

### DIFF
--- a/docs/developers/protocol/hermez-protocol/protocol.md
+++ b/docs/developers/protocol/hermez-protocol/protocol.md
@@ -228,7 +228,13 @@ There are two ways to authorize an account creation (that is, an ethereum addres
 - Via ethereum transaction, which has an implicit signature of the ethereum address.  This requires the owner of the ethereum address to sign the smart contract transaction call
 - Via an authorization signature (`AccountCreationAuthSig`) that can be used by any party to create accounts on behalf of the user
 
-`AccountCreationAuthMsg = "I authorize this babyjubjub key for hermez rollup account creation" || compressed-bjj`
+```
+[32 bytes] compressed-bjj
+[ 2 bytes] chainId
+[20 bytes] hermezAddress
+```
+
+`AccountCreationAuthMsg = "I authorize this babyjubjub key for hermez rollup account creation" || compressed-bjj || chainId || hermezAddress`
 
 `AccountCreationAuthSig = Sign_ecdsa(AccountCreationAuthMsg)`
 


### PR DESCRIPTION
Regarding  TOB-HERMEZ-017: _checkSig allows signatures reuse

2 new fields added to the babyjub authorization signature:

- `chainId` 2 bytes
- `hermezAddress  (ethereum address of hermez contract)` 20 bytes

Old: `AccountCreationAuthMsg = "I authorize this babyjubjub key for hermez rollup account creation" || compressed-bjj`

New: `AccountCreationAuthMsg = "I authorize this babyjubjub key for hermez rollup account creation" || compressed-bjj || chainId || hermezAddress`

Updated contracts in https://github.com/hermeznetwork/contracts/pull/20